### PR TITLE
The Node.js 18 has been been promoted to LTS version since 2022-10-25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '14', '16' ]
+        node: [ '14', '16', '18' ]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
- https://github.com/nodejs/release#release-schedule